### PR TITLE
RFR: actually use the retry count passed into Connection

### DIFF
--- a/aiclib/core.py
+++ b/aiclib/core.py
@@ -180,8 +180,12 @@ class Connection(object):
         return new_body, new_url
 
     def request(self, method, url, generationnumber=0, body=None,
-                retries=0, is_url_prepared=False, is_body_prepared=False,
+                retries=None, is_url_prepared=False, is_body_prepared=False,
                 max_redirects=5):
+
+        if retries is None:
+            retries = self.retries
+
         if not self.authenticated:
             self._login(self.username, self.password)
 

--- a/aiclib/core.py
+++ b/aiclib/core.py
@@ -253,8 +253,8 @@ class Connection(object):
         # request returned, we need to raise.
         comment = "Maximum retries/redirects exceeded."
         if r:
-            comment = (comment + " Last request: %s: %s"
-                       % (r.reason, r.data))
+            comment = (comment + " Last request: %s %s %s"
+                       % (r.status, r.reason, r.data))
         logger.error(comment)
         raise AICException(500, comment)
 

--- a/tests/base.py
+++ b/tests/base.py
@@ -71,7 +71,8 @@ class UnitTestBase(tests.TestCase):
         self._patcher.start()
         self.addCleanup(self._patcher.stop)
 
-    def _add_response(self, url, status=200, reason=None, body=None, headers=None):
+    def _add_response(self, url, status=200, reason=None,
+                      body=None, headers=None):
         path = urlparse(url).path
         self._responses[path].append(_fake_response(
             status, reason, body, headers))

--- a/tests/unit/fixtures.py
+++ b/tests/unit/fixtures.py
@@ -1,0 +1,83 @@
+import json
+
+LSWITCH_Q = json.dumps(json.loads("""
+{
+  "results": [
+    {
+      "display_name": "lswitch1",
+      "_href": "/ws.v1/lswitch/0fb9adc9-3b7e-41da-bd2a-43da65311111",
+      "tags": [
+        {
+          "scope": "os_tid",
+          "tag": "12345"
+        },
+        {
+          "scope": "neutron_net_id",
+          "tag": "0edf4a88-975b-4b19-aeda-ff657494df1c"
+        }
+      ],
+      "transport_zones": [
+        {
+          "zone_uuid": "3e2b4fcd-6875-44fe-acae-e640b625a216",
+          "binding_config": {
+            "vxlan_transport": [
+              {
+                "transport": 11111
+              }
+            ],
+            "vlan_translation": []
+          },
+          "transport_type": "vxlan"
+        },
+        {
+          "zone_uuid": "3e2b4fcd-6875-44fe-acae-e640b625a216",
+          "transport_type": "stt"
+        }
+      ],
+      "_schema": "/ws.v1/schema/LogicalSwitchConfig",
+      "port_isolation_enabled": false,
+      "replication_mode": "service",
+      "type": "LogicalSwitchConfig",
+      "uuid": "0fb9adc9-3b7e-41da-bd2a-43da65311111"
+    },
+    {
+      "display_name": "lswitch2",
+      "_href": "/ws.v1/lswitch/0fb9adc9-3b7e-41da-bd2a-43da65322222",
+      "tags": [
+        {
+          "scope": "os_tid",
+          "tag": "12345"
+        },
+        {
+          "scope": "neutron_net_id",
+          "tag": "0edf4a88-975b-4b19-aeda-ff657494df1c"
+        }
+      ],
+      "transport_zones": [
+        {
+          "zone_uuid": "3e2b4fcd-6875-44fe-acae-e640b625a216",
+          "binding_config": {
+            "vxlan_transport": [
+              {
+                "transport": 22222
+              }
+            ],
+            "vlan_translation": []
+          },
+          "transport_type": "vxlan"
+        },
+        {
+          "zone_uuid": "3e2b4fcd-6875-44fe-acae-e640b625a216",
+          "transport_type": "stt"
+        }
+      ],
+      "_schema": "/ws.v1/schema/LogicalSwitchConfig",
+      "port_isolation_enabled": false,
+      "replication_mode": "service",
+      "type": "LogicalSwitchConfig",
+      "uuid": "0fb9adc9-3b7e-41da-bd2a-43da65322222"
+    }
+  ],
+  "result_count": 2
+}
+"""))

--- a/tests/unit/test_core.py
+++ b/tests/unit/test_core.py
@@ -1,0 +1,53 @@
+# Copyright 2015 Rackspace
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import aiclib
+import tests.base as test_base
+
+from tests.unit import fixtures
+
+class ConnectionTestCase(test_base.UnitTestBase):
+    def setUp(self):
+        super(ConnectionTestCase, self).setUp()
+
+        self.connection = aiclib.nvp.Connection("https://localhost",
+          username='fakeuser', password='fakepass', retries=2)
+
+    def test_connection_retries_unauthorized(self):
+
+        # we expect to query lswitches (and auth once), return 401 on the
+        # second lswitch query (triggering a re-auth), and finally succeed
+        # the third call.
+        self._add_response(
+            '/ws.v1/login', status=200, headers={'set-cookie': 'fakecookie'})
+        self._add_response(
+            '/ws.v1/login', status=200, headers={'set-cookie': 'fakecookie'})
+
+        self._add_response(
+            '/ws.v1/lswitch', status=200, body=fixtures.LSWITCH_Q,
+            headers={"content-type": "application/json",
+                     "content-length": str(len(fixtures.LSWITCH_Q))})
+        self._add_response(
+            '/ws.v1/lswitch', status=401, reason='Unauthorized')
+        self._add_response(
+            '/ws.v1/lswitch', status=200, body=fixtures.LSWITCH_Q,
+            headers={"content-type": "application/json",
+                     "content-length": str(len(fixtures.LSWITCH_Q))})
+
+        # First call, should succeed
+        self.connection.lswitch().query().results()
+
+        # Second call, should be unauthorized, reauth, and then succeed.
+        self.connection.lswitch().query().results()
+

--- a/tests/unit/test_nvpentity.py
+++ b/tests/unit/test_nvpentity.py
@@ -27,25 +27,27 @@ class LSwitchTestCase(test_base.UnitTestBase):
         self.assertIsNone(self.lswitch.get("transport_zones"))
 
         cases = (
-            (('zone-uuid', 'vxlan'),
-              {'vlan_id': 1337, 'vxlan_id': 31337},
-              [{
-                'zone_uuid': 'zone-uuid',
-                'binding_config': {
-                    "vlan_translation": [{'transport': 1337}],
-                    "vxlan_transport": [{'transport': 31337}]
-                },
-                'transport_type': 'vxlan'
-             }]),
-             (('zone-uuid', 'gre'),
-              {'vlan_id': 1337},
-              [{
-                'zone_uuid': 'zone-uuid',
-                'binding_config': {
-                    "vlan_translation": [{'transport': 1337}],
-                },
-                'transport_type': 'gre'
-             }]),
+            (
+                ('zone-uuid', 'vxlan'),
+                {'vlan_id': 1337, 'vxlan_id': 31337},
+                [{
+                    'zone_uuid': 'zone-uuid',
+                    'binding_config': {
+                        "vlan_translation": [{'transport': 1337}],
+                        "vxlan_transport": [{'transport': 31337}]},
+                    'transport_type': 'vxlan'
+                }]
+            ),
+            (
+                ('zone-uuid', 'gre'),
+                {'vlan_id': 1337},
+                [{
+                    'zone_uuid': 'zone-uuid',
+                    'binding_config': {
+                        "vlan_translation": [{'transport': 1337}]},
+                    'transport_type': 'gre'
+                }]
+            ),
         )
 
         for case in cases:


### PR DESCRIPTION
Few problems fixed here:

1) We weren't using the Connection class retry default if specified, so we were always setting retries to 1. This didn't give us a chance to retry the call if we hit a 401.
2) We never updated the headers on subsequent retries, so even if we did successfully re-auth we weren't passing in the new cookie.
3) If we ran out of retries, we were returning ```None``` instead of raising, so the callers would blow up trying to access the response object.

Also added a few tests covering this, as well as a little mini-framework for mocking out requests that we could use to write unit tests if desired. 