### PR TITLE
refactor connection retry to support reauth and redirect

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -17,6 +17,28 @@ import os
 import aiclib
 import tests
 
+import mock
+
+import collections
+import urllib3
+import io
+
+try:
+    from urllib import parse as urlparse
+except ImportError:
+    from urlparse import urlparse
+
+
+def _fake_response(status, reason, body, headers):
+    """Generate a fake urllib3 response object."""
+    return urllib3.HTTPResponse(
+            status=status,
+            reason=reason,
+            body=io.BytesIO(body) if body else io.BytesIO(),
+            headers=headers,
+            preload_content=False
+    )
+
 
 class IntegrationTestBase(tests.TestCase):
 
@@ -25,13 +47,41 @@ class IntegrationTestBase(tests.TestCase):
         default_user = "admin"
         default_password = "password"
 
-        url = os.getenv('AICLIB_NVP_URL', default)
-        username = os.getenv('AICLIB_NVP_USERNAME', default_user)
-        password = os.getenv('AICLIB_NVP_PASSWORD', default_password)
-        self.nvp = aiclib.nvp.Connection(url, username=username,
-                                         password=password)
+        self.urls = os.getenv('AICLIB_NVP_URL', default).split(',')
+        self.username = os.getenv('AICLIB_NVP_USERNAME', default_user)
+        self.password = os.getenv('AICLIB_NVP_PASSWORD', default_password)
+
+        self.nvp = aiclib.nvp.Connection(self.urls[0],
+                                         username=self.username,
+                                         password=self.password)
 
 
 class UnitTestBase(tests.TestCase):
     def setUp(self):
         super(UnitTestBase, self).setUp()
+        self._responses = collections.defaultdict(list)
+        self._calls = []
+
+        # Mock out urllib3, allowing us to specify return values for
+        # particular urls in our tests.
+        def _urlopen(pool, method, url, body=None, headers=None, **kwargs):
+            self._calls.append(
+                (pool, method, url, body, headers.copy(), kwargs.copy()))
+            return self._get_response(url)
+
+        target = 'urllib3.connectionpool.HTTPConnectionPool.urlopen'
+        self._patcher = mock.patch(target, _urlopen)
+        self._patcher.start()
+        self.addCleanup(self._patcher.stop)
+
+    def _add_response(self, url, status=200, reason=None,
+                      body=None, headers=None):
+        path = urlparse(url).path
+        self._responses[path].append(_fake_response(
+            status, reason, body, headers))
+
+    def _get_response(self, url):
+        response = self._responses.get(urlparse(url).path, [])
+        if not response:
+            raise Exception("No mock response added for %s" % (url))
+        return response.pop(0)

--- a/tests/integration/test_Connection.py
+++ b/tests/integration/test_Connection.py
@@ -1,0 +1,62 @@
+# vim: tabstop=4 shiftwidth=4 softtabstop=4
+
+# Copyright 2013 Rackspace
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""
+Created: August 27, 2012
+
+@author: Justin Hammond, Rackspace Hosting
+"""
+
+import aiclib
+
+import tests.base
+
+class TestConnectionRedirect(tests.base.IntegrationTestBase):
+
+    def setUp(self):
+        super(TestConnectionRedirect, self).setUp()
+
+        if len(self.urls) < 2:
+            self.skipTest('Addition URLs required for redirection test.')
+
+        self.nvp2 = aiclib.nvp.Connection(self.urls[1],
+                                         username=self.username,
+                                         password=self.password)
+
+    def tearDown(self):
+        if hasattr(self, 'switch'):
+            self.nvp.lswitch(self.switch).delete()
+
+    def test_redirect(self):
+
+        # assert we are pointed at 2 different controllers
+        self.assertNotEqual(self.nvp.connection._conn.host,
+                            self.nvp2.connection._conn.host)
+
+        # create a switch, and query it from both controllers
+        self.switch = self.nvp.lswitch().create()
+        query1 = self.nvp.lswitch().query()
+        results1 = query1.uuid(self.switch['uuid']).results()
+        query2 = self.nvp2.lswitch().query()
+        results2 = query2.uuid(self.switch['uuid']).results()
+
+        # assert that both connections are now pointed at the same
+        # host
+        self.assertEqual(self.nvp.connection._conn.host,
+                         self.nvp2.connection._conn.host)
+        self.assertEqual(results1, results2)
+
+

--- a/tests/unit/fixtures.py
+++ b/tests/unit/fixtures.py
@@ -1,0 +1,83 @@
+import json
+
+LSWITCH_Q = json.dumps(json.loads("""
+{
+  "results": [
+    {
+      "display_name": "lswitch1",
+      "_href": "/ws.v1/lswitch/0fb9adc9-3b7e-41da-bd2a-43da65311111",
+      "tags": [
+        {
+          "scope": "os_tid",
+          "tag": "12345"
+        },
+        {
+          "scope": "neutron_net_id",
+          "tag": "0edf4a88-975b-4b19-aeda-ff657494df1c"
+        }
+      ],
+      "transport_zones": [
+        {
+          "zone_uuid": "3e2b4fcd-6875-44fe-acae-e640b625a216",
+          "binding_config": {
+            "vxlan_transport": [
+              {
+                "transport": 11111
+              }
+            ],
+            "vlan_translation": []
+          },
+          "transport_type": "vxlan"
+        },
+        {
+          "zone_uuid": "3e2b4fcd-6875-44fe-acae-e640b625a216",
+          "transport_type": "stt"
+        }
+      ],
+      "_schema": "/ws.v1/schema/LogicalSwitchConfig",
+      "port_isolation_enabled": false,
+      "replication_mode": "service",
+      "type": "LogicalSwitchConfig",
+      "uuid": "0fb9adc9-3b7e-41da-bd2a-43da65311111"
+    },
+    {
+      "display_name": "lswitch2",
+      "_href": "/ws.v1/lswitch/0fb9adc9-3b7e-41da-bd2a-43da65322222",
+      "tags": [
+        {
+          "scope": "os_tid",
+          "tag": "12345"
+        },
+        {
+          "scope": "neutron_net_id",
+          "tag": "0edf4a88-975b-4b19-aeda-ff657494df1c"
+        }
+      ],
+      "transport_zones": [
+        {
+          "zone_uuid": "3e2b4fcd-6875-44fe-acae-e640b625a216",
+          "binding_config": {
+            "vxlan_transport": [
+              {
+                "transport": 22222
+              }
+            ],
+            "vlan_translation": []
+          },
+          "transport_type": "vxlan"
+        },
+        {
+          "zone_uuid": "3e2b4fcd-6875-44fe-acae-e640b625a216",
+          "transport_type": "stt"
+        }
+      ],
+      "_schema": "/ws.v1/schema/LogicalSwitchConfig",
+      "port_isolation_enabled": false,
+      "replication_mode": "service",
+      "type": "LogicalSwitchConfig",
+      "uuid": "0fb9adc9-3b7e-41da-bd2a-43da65322222"
+    }
+  ],
+  "result_count": 2
+}
+"""))

--- a/tests/unit/test_core.py
+++ b/tests/unit/test_core.py
@@ -1,0 +1,206 @@
+# Copyright 2015 Rackspace
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import aiclib
+import tests.base as test_base
+
+from tests.unit import fixtures
+
+
+class ConnectionTestCase(test_base.UnitTestBase):
+    def setUp(self):
+        super(ConnectionTestCase, self).setUp()
+
+        self.connection = aiclib.nvp.Connection(
+            "https://localhost", username='fakeuser', password='fakepass',
+            retries=2, backoff=0)
+
+    def test_connection_retries_unauthorized(self):
+        self._add_response(
+            '/ws.v1/login', status=200, headers={'set-cookie': 'fakecookie'})
+        self._add_response(
+            '/ws.v1/login', status=200, headers={'set-cookie': 'fakecookie2'})
+
+        self._add_response(
+            '/ws.v1/lswitch', status=200, body=fixtures.LSWITCH_Q,
+            headers={"content-type": "application/json",
+                     "content-length": str(len(fixtures.LSWITCH_Q))})
+        self._add_response(
+            '/ws.v1/lswitch', status=401, reason='Unauthorized')
+        self._add_response(
+            '/ws.v1/lswitch', status=200, body=fixtures.LSWITCH_Q,
+            headers={"content-type": "application/json",
+                     "content-length": str(len(fixtures.LSWITCH_Q))})
+
+        # First call, should succeed
+        response = self.connection.lswitch().query().results()
+        # Second call, should be unauthorized, reauth, and then succeed.
+        response2 = self.connection.lswitch().query().results()
+
+        # sanity check response object
+        self.assertEqual(response['results'][0]['display_name'],
+                         'lswitch1')
+        self.assertEqual(response, response2)
+
+        # 2x auth and 3x lswitch query
+        self.assertEqual(len(self._calls), 5)
+
+    def test_connection_reauth_uses_new_cookie(self):
+        self._add_response(
+            '/ws.v1/login', status=200, headers={'set-cookie': 'fakecookie'})
+        self._add_response(
+            '/ws.v1/login', status=200, headers={'set-cookie': 'fakecookie2'})
+
+        self._add_response(
+            '/ws.v1/lswitch', status=200, body=fixtures.LSWITCH_Q,
+            headers={"content-type": "application/json",
+                     "content-length": str(len(fixtures.LSWITCH_Q))})
+        self._add_response(
+            '/ws.v1/lswitch', status=401, reason='Unauthorized')
+        self._add_response(
+            '/ws.v1/lswitch', status=200, body=fixtures.LSWITCH_Q,
+            headers={"content-type": "application/json",
+                     "content-length": str(len(fixtures.LSWITCH_Q))})
+
+        # First call, should succeed
+        self.connection.lswitch().query().results()
+        # Second call, should be unauthorized, reauth, and then succeed.
+        self.connection.lswitch().query().results()
+
+        # Assert the value of the Cookie is set correctly - first 2
+        # lswitch calls use the first cookie, the second one 401s,
+        # reauth happens, and the 3rd call uses the new cookie.
+        self.assertEqual(self._calls[1][4]['Cookie'], 'fakecookie')
+        self.assertEqual(self._calls[2][4]['Cookie'], 'fakecookie')
+        self.assertEqual(self._calls[4][4]['Cookie'], 'fakecookie2')
+
+    def test_connection_retry_exhaustion_raises(self):
+        self._add_response(
+            '/ws.v1/login', status=200, headers={'set-cookie': 'fakecookie'})
+        self._add_response(
+            '/ws.v1/login', status=200, headers={'set-cookie': 'fakecookie'})
+        self._add_response(
+            '/ws.v1/login', status=200, headers={'set-cookie': 'fakecookie'})
+
+        self._add_response(
+            '/ws.v1/lswitch', status=401, reason='Unauthorized')
+        self._add_response(
+            '/ws.v1/lswitch', status=401, reason='Unauthorized')
+
+        msg = 'Max retries reached'
+        with self.assertRaises(aiclib.core.AICException) as e:
+            self.connection.connection.request(
+                'GET', '/ws.v1/lswitch', retries=1)
+
+        self.assertEqual(e.exception.code, 408)
+        self.assertTrue(msg in e.exception.message)
+
+    def test_connection_redirect_once(self):
+        """Test redirecting succeeds."""
+        # we expect to query lswitches (and auth once), return 401 on the
+        # second lswitch query (triggering a re-auth), and finally succeed
+        # the third call.
+        self._add_response(
+            '/ws.v1/login', status=200, headers={'set-cookie': 'fakecookie'})
+        self._add_response(
+            '/ws.v1/login', status=200, headers={'set-cookie': 'fakecookie2'})
+
+        self._add_response(
+            '/ws.v1/lswitch', status=301,
+            headers={'location': 'https://newhost:443/ws.v1/lswitch'})
+        self._add_response(
+            '/ws.v1/lswitch', status=200, body=fixtures.LSWITCH_Q,
+            headers={"content-type": "application/json",
+                     "content-length": str(len(fixtures.LSWITCH_Q))})
+
+        response = self.connection.lswitch().query().results()
+        self.assertEqual(response['results'][0]['display_name'],
+                         'lswitch1')
+
+        # assert that after redirect we actually re-auth and use the new cookie
+        self.assertEqual(self._calls[1][4]['Cookie'], 'fakecookie')
+        self.assertEqual(self._calls[3][4]['Cookie'], 'fakecookie2')
+
+        # assert that we are making redirected requests against the new host
+        self.assertEqual(self._calls[0][0].host, 'localhost')
+        self.assertEqual(self._calls[1][0].host, 'localhost')
+        self.assertEqual(self._calls[2][0].host, 'newhost')
+        self.assertEqual(self._calls[3][0].host, 'newhost')
+
+    def test_connection_redirect_multiple(self):
+        """Test redirecting multiple times succeeds."""
+        self._add_response(
+            '/ws.v1/login', status=200, headers={'set-cookie': 'fakecookie'})
+        self._add_response(
+            '/ws.v1/login', status=200, headers={'set-cookie': 'fakecookie2'})
+        self._add_response(
+            '/ws.v1/login', status=200, headers={'set-cookie': 'fakecookie3'})
+
+        self._add_response(
+            '/ws.v1/lswitch', status=301,
+            headers={'location': 'https://newhost:443/ws.v1/lswitch'})
+        self._add_response(
+            '/ws.v1/lswitch', status=301,
+            headers={'location': 'https://anotherhost:443/ws.v1/lswitch'})
+        self._add_response(
+            '/ws.v1/lswitch', status=200, body=fixtures.LSWITCH_Q,
+            headers={"content-type": "application/json",
+                     "content-length": str(len(fixtures.LSWITCH_Q))})
+
+        response = self.connection.lswitch().query().results()
+        self.assertEqual(response['results'][0]['display_name'],
+                         'lswitch1')
+
+        # assert that after redirect we actually re-auth and use
+        # the new cookie
+        self.assertEqual(self._calls[1][4]['Cookie'], 'fakecookie')
+        self.assertEqual(self._calls[3][4]['Cookie'], 'fakecookie2')
+        self.assertEqual(self._calls[5][4]['Cookie'], 'fakecookie3')
+
+        # assert that we are making redirected requests against
+        # the new host
+        self.assertEqual(self._calls[0][0].host, 'localhost')
+        self.assertEqual(self._calls[1][0].host, 'localhost')
+        self.assertEqual(self._calls[2][0].host, 'newhost')
+        self.assertEqual(self._calls[3][0].host, 'newhost')
+        self.assertEqual(self._calls[4][0].host, 'anotherhost')
+        self.assertEqual(self._calls[5][0].host, 'anotherhost')
+
+    def test_connection_redirect_exhaustion_raises(self):
+        """Test redirecting 'retries' times raises."""
+        self._add_response(
+            '/ws.v1/login', status=200, headers={'set-cookie': 'fakecookie'})
+        self._add_response(
+            '/ws.v1/login', status=200, headers={'set-cookie': 'fakecookie2'})
+        self._add_response(
+            '/ws.v1/login', status=200, headers={'set-cookie': 'fakecookie3'})
+
+        self._add_response(
+            '/ws.v1/lswitch', status=301,
+            headers={'location': 'https://newhost:443/ws.v1/lswitch'})
+        self._add_response(
+            '/ws.v1/lswitch', status=301,
+            headers={'location': 'https://anotherhost:443/ws.v1/lswitch'})
+        self._add_response(
+            '/ws.v1/lswitch', status=200, body=fixtures.LSWITCH_Q,
+            headers={"content-type": "application/json",
+                     "content-length": str(len(fixtures.LSWITCH_Q))})
+
+        msg = 'Max retries reached'
+        with self.assertRaises(aiclib.core.AICException) as e:
+            self.connection.connection.request('GET', '/ws.v1/lswitch',
+                                               retries=0)
+
+        self.assertEqual(e.exception.code, 408)
+        self.assertTrue(msg in e.exception.message)

--- a/tests/unit/test_nvpentity.py
+++ b/tests/unit/test_nvpentity.py
@@ -27,25 +27,27 @@ class LSwitchTestCase(test_base.UnitTestBase):
         self.assertIsNone(self.lswitch.get("transport_zones"))
 
         cases = (
-            (('zone-uuid', 'vxlan'),
-              {'vlan_id': 1337, 'vxlan_id': 31337},
-              [{
-                'zone_uuid': 'zone-uuid',
-                'binding_config': {
-                    "vlan_translation": [{'transport': 1337}],
-                    "vxlan_transport": [{'transport': 31337}]
-                },
-                'transport_type': 'vxlan'
-             }]),
-             (('zone-uuid', 'gre'),
-              {'vlan_id': 1337},
-              [{
-                'zone_uuid': 'zone-uuid',
-                'binding_config': {
-                    "vlan_translation": [{'transport': 1337}],
-                },
-                'transport_type': 'gre'
-             }]),
+            (
+                ('zone-uuid', 'vxlan'),
+                {'vlan_id': 1337, 'vxlan_id': 31337},
+                [{
+                    'zone_uuid': 'zone-uuid',
+                    'binding_config': {
+                        "vlan_translation": [{'transport': 1337}],
+                        "vxlan_transport": [{'transport': 31337}]},
+                    'transport_type': 'vxlan'
+                }]
+            ),
+            (
+                ('zone-uuid', 'gre'),
+                {'vlan_id': 1337},
+                [{
+                    'zone_uuid': 'zone-uuid',
+                    'binding_config': {
+                        "vlan_translation": [{'transport': 1337}]},
+                    'transport_type': 'gre'
+                }]
+            ),
         )
 
         for case in cases:


### PR DESCRIPTION
This is a second stab at fixing auth retries, by refactoring.

This keeps the same request logic as before, with the added feature that if the request is a redirected request it will update the underlying connection pool to point at the new location.

